### PR TITLE
Check num_remaining before trying to push to S3

### DIFF
--- a/Cloud/API.php
+++ b/Cloud/API.php
@@ -191,6 +191,11 @@ class Cloud_API
         // Request S3 data
         $s3 = $this->_execute('http://my.cl.ly/items/new');
 
+		// Check if we can upload
+		if(isset($s3->num_remaining) && $s3->num_remaining < 1) {
+			throw new Cloud_Exception('Insufficient uploads remaining. Please consider upgrading to CloudApp Pro', CLOUD_EXCEPTION_PRO);
+		}
+
         // Create body and upload file
         $body = array();
         foreach ($s3->params as $key => $value) {

--- a/Cloud/API.php
+++ b/Cloud/API.php
@@ -190,14 +190,11 @@ class Cloud_API
 
         // Request S3 data
         $s3 = $this->_execute('http://my.cl.ly/items/new');
-        if ($s3-> uploads_remaining < 1) {
-            throw new CloudException('Account has reached its maximum number of uploads for the day.', CLOUD_EXCEPTION_MAX_UPLOADS);
-        }
 
-		// Check if we can upload
-		if(isset($s3->num_remaining) && $s3->num_remaining < 1) {
-			throw new Cloud_Exception('Insufficient uploads remaining. Please consider upgrading to CloudApp Pro', CLOUD_EXCEPTION_PRO);
-		}
+        // Check if we can upload
+        if(isset($s3->num_remaining) && $s3->num_remaining < 1) {
+            throw new Cloud_Exception('Insufficient uploads remaining. Please consider upgrading to CloudApp Pro', CLOUD_EXCEPTION_PRO);
+        }
 
         // Create body and upload file
         $body = array();

--- a/Cloud/API.php
+++ b/Cloud/API.php
@@ -190,6 +190,9 @@ class Cloud_API
 
         // Request S3 data
         $s3 = $this->_execute('http://my.cl.ly/items/new');
+        if ($s3-> uploads_remaining < 1) {
+            throw new CloudException('Account has reached its maximum number of uploads for the day.', CLOUD_EXCEPTION_MAX_UPLOADS);
+        }
 
         // Create body and upload file
         $body = array();

--- a/Cloud/Exception.php
+++ b/Cloud/Exception.php
@@ -23,6 +23,7 @@ define('CLOUD_EXCEPTION_FILE_NOT_READABLE', 1);
 define('CLOUD_EXCEPTION_FILE_NOT_FOUND',    2);
 define('CLOUD_EXCEPTION_FILE_INVALID',      3);
 define('CLOUD_EXCEPTION_INVALID_RESPONSE',  4);
+define('CLOUD_EXCEPTION_PRO',               5);
 
 /**
  * Exception class used by Cloud_API.


### PR DESCRIPTION
When attempting to upload (add_file), and you've reached your maximum number of uploads, CloudApp doesn't return an S3 key. Rather than continue blindly and erroring-out on S3's unexpected HTTP code, check num_remaining from CloudApp and throw a a more descriptive exception.
